### PR TITLE
chore(build): adding build for basic dmaas-operator binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Folders
+_obj
+_test
+_output
+.idea/
+
+.container-*
+.vimrc
+.go
+.DS_Store
+.vscode
+*.diff
+

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# repo's import path
+PACKAGE=github.com/mayadata-io/dmaas-operator
+
+git_branch := $(shell git rev-parse --abbrev-ref HEAD)
+git_tag := $(shell git describe --exact-match --abbrev=0 2>/dev/null || echo "")
+
+VERSION ?= $(if $(git_tag),$(git_tag),$(git_branch))
+
+GOOS ?= $(shell go env GOOS)
+GOARCH ?= $(shell go env GOARCH)
+
+build-dirs:
+	@mkdir -p _output/bin/$(GOOS)/$(GOARCH)
+
+build: build-dirs
+	GOOS=$(GOOS) \
+	GOARCH=$(GOARCH) \
+	VERSION=$(VERSION) \
+	PACKAGE=$(PACKAGE) \
+	OUTPUT_DIR=$$(pwd)/_output/bin/$(GOOS)/$(GOARCH) \
+	./hack/build.sh
+
 clean:
 	@rm -rf .go _output
 
 update:
 	@hack/verify-update.sh
-
+	@hack/check-license.sh

--- a/cmd/dmaas-operator/main.go
+++ b/cmd/dmaas-operator/main.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2020 The MayaData Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/mayadata-io/dmaas-operator/pkg/cmd"
+	"k8s.io/klog"
+)
+
+func main() {
+	defer klog.Flush()
+
+	prog := filepath.Base(os.Args[0])
+
+	err := cmd.NewCommand(prog).Execute()
+	cmd.CheckError(err)
+}

--- a/doc/build.md
+++ b/doc/build.md
@@ -1,0 +1,25 @@
+## Building dmaas-operator
+
+dmaas-operator is written in [go language](https://golang.org/doc/install). Supported Go version is 1.14.
+
+## Building code
+To build dmaas-operator, run
+
+```bash
+make build
+```
+
+Above command will build the binary and place it under `_output/bin/linux/amd64/` or `_output/bin/${GOOS}/${GOARCH}.
+
+## Updating generated code
+We are using following tools to generate relevant code(lister,informer,clientset,deepcopy,crd) for `pkg/apis/mayadata.io`.
+- [code-generator](https://github.com/kubernetes/code-generator) for lister,informer,clientset,deepcopy
+- [controller-tools](https://github.com/kubernetes-sigs/controller-tools) for crd
+
+Make sure that above tools are installed in your system.
+
+To update the generated code, run
+
+```bash
+make update
+```

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,7 @@ github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
+github.com/client9/misspell v0.3.4 h1:ta993UF76GwbvJcIo3Y68y/M3WxlpEHPWIGDkJYwzJI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -1,0 +1,48 @@
+#!/bin/bash -e
+
+if [ -z "$GOOS" ]; then
+	echo "Empty GOOS"
+	exit 1
+fi
+
+if [ -z "$GOARCH" ]; then
+	echo "Empty GOARCH"
+	exit 1
+fi
+
+if [ -z "$VERSION" ]; then
+	echo "Empty VERSION"
+	exit 1
+fi
+
+if [ -z "$PACKAGE" ]; then
+	echo "Empty PACKAGE"
+	exit 1
+fi
+
+if [[ -z "${OUTPUT_DIR:-}" ]]; then
+  OUTPUT_DIR=.
+fi
+
+OUTPUT=${OUTPUT_DIR}/dmaas-operator
+
+GIT_SHA=$(git rev-parse HEAD)
+git_dirty=$(git status --porcelain 2> /dev/null)
+if [[ -z "${git_dirty}" ]]; then
+  GIT_TREE_STATE=clean
+else
+  GIT_TREE_STATE=dirty
+fi
+
+LDFLAGS="-X ${PACKAGE}/pkg/cmd.Version=${VERSION}"
+LDFLAGS="${LDFLAGS} -X ${PACKAGE}/pkg/cmd.GitSHA=${GIT_SHA}"
+LDFLAGS="${LDFLAGS} -X ${PACKAGE}/pkg/cmd.GitTreeState=${GIT_TREE_STATE}"
+
+export CGO_ENABLED=0
+
+go build \
+  -o ${OUTPUT} \
+  -installsuffix "static" \
+  -ldflags "${LDFLAGS}" \
+  ${PACKAGE}/cmd/dmaas-operator
+

--- a/hack/check-license.sh
+++ b/hack/check-license.sh
@@ -12,13 +12,17 @@
 
 set -e
 
+FILE_LIST=$(mktemp)
 echo ">> checking license header"
-licRes=$$(for file in $$(find . -type f -iname '*.go' ! -path './vendor/*' ! -path './pkg/debug/*' ) ; do \
-		awk 'NR<=3' $$file | grep -Eq "(Copyright|generated|GENERATED)" || echo $$file; \
-	done);
-if [ -n "$${licRes}" ]; then
-	echo "license header checking failed:"
-	echo "$${licRes}"
+for file in $(find . -type f -iname '*.go') ; do
+	awk 'NR<=3' $file | grep -Eq "(Copyright|generated|GENERATED)" || echo $file >> $FILE_LIST
+done
+
+if [ $(cat $FILE_LIST |wc -l) -ne 0 ]; then
+	echo "license header checking failed. Following files doesn't have license"
+	cat $FILE_LIST
+	rm $FILE_LIST
 	exit 1
 fi
+rm $FILE_LIST
 

--- a/pkg/cmd/base.go
+++ b/pkg/cmd/base.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2020 The MayaData Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package cmd provides function for command utility
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// NewCommand returns the command for dmaas-operator
+func NewCommand(name string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   name,
+		Short: "DMaaS operator to backup and restore k8s resources",
+	}
+
+	config := NewConfig()
+
+	cmd.AddCommand(
+		NewCmdVersion(),
+		NewCmdServer(config),
+	)
+
+	return cmd
+}
+
+// CheckError verify the given error
+func CheckError(err error) {
+	if err != nil {
+		fmt.Printf("Error occurred: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2020 The MayaData Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"github.com/spf13/pflag"
+
+	clientset "github.com/mayadata-io/dmaas-operator/pkg/generated/clientset/versioned"
+	"github.com/pkg/errors"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// Config interface provides api to access clientset and namespace
+type Config interface {
+	// BindFlags binds common flags (--kubeconfig, --namespace) to the passed-in FlagSet.
+	BindFlags(flags *pflag.FlagSet)
+	// Client returns dmaas-operator client.
+	Client() (clientset.Interface, error)
+	// KubeClient returns Kubernetes client.
+	KubeClient() (kubernetes.Interface, error)
+	// SetClientQPS sets the Queries Per Second for a client.
+	SetClientQPS(float32)
+	// SetClientBurst sets the Burst for a client.
+	SetClientBurst(int)
+	// GetNamespace return dmaas namespace
+	GetNamespace() string
+}
+
+type config struct {
+	kubeconfig  string
+	namespace   string
+	clientQPS   float32
+	clientBurst int
+	flags       *pflag.FlagSet
+}
+
+// NewConfig return config for clientset
+func NewConfig() Config {
+	c := &config{
+		flags: pflag.NewFlagSet("", pflag.ContinueOnError),
+	}
+
+	c.namespace = "dmaas"
+
+	c.flags.StringVar(&c.kubeconfig,
+		"kubeconfig",
+		"",
+		"Path to the kubeconfig file to use to talk to the Kubernetes apiserver. If unset, try the environment variable KUBECONFIG, as well as in-cluster configuration",
+	)
+	c.flags.StringVarP(&c.namespace,
+		"namespace",
+		"n",
+		c.namespace,
+		"The namespace in which dmaas-operator should operate",
+	)
+
+	return c
+}
+
+// BindFlags binds common flags to the given flagset
+func (c *config) BindFlags(flags *pflag.FlagSet) {
+	flags.AddFlagSet(c.flags)
+}
+
+// ClientConfig return cluster config
+func (c *config) ClientConfig() (*rest.Config, error) {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	loadingRules.ExplicitPath = c.kubeconfig
+	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, nil)
+
+	clientConfig, err := kubeConfig.ClientConfig()
+	if err != nil {
+		return nil, errors.Wrap(err, "error finding Kubernetes API server config in --kubeconfig, $KUBECONFIG, or in-cluster configuration")
+	}
+
+	if c.clientQPS > 0.0 {
+		clientConfig.QPS = c.clientQPS
+	}
+
+	if c.clientBurst > 0 {
+		clientConfig.Burst = c.clientBurst
+	}
+
+	return clientConfig, nil
+}
+
+// Client returns clientset to access dmaas-operator resources
+func (c *config) Client() (clientset.Interface, error) {
+	clientConfig, err := c.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := clientset.NewForConfig(clientConfig)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return client, nil
+}
+
+// KubeClient return clientset to access k8s native resources
+func (c *config) KubeClient() (kubernetes.Interface, error) {
+	clientConfig, err := c.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	kubeClient, err := kubernetes.NewForConfig(clientConfig)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return kubeClient, nil
+}
+
+// SetClientQPS set given qps value to config
+func (c *config) SetClientQPS(qps float32) {
+	c.clientQPS = qps
+}
+
+// SetClientBurst set given burst value to config
+func (c *config) SetClientBurst(burst int) {
+	c.clientBurst = burst
+}
+
+// GetNamespace return the namespace of dmaas-operator
+func (c *config) GetNamespace() string {
+	return c.namespace
+}

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -14,6 +14,8 @@ limitations under the License.
 package cmd
 
 import (
+	"os"
+
 	"github.com/spf13/pflag"
 
 	clientset "github.com/mayadata-io/dmaas-operator/pkg/generated/clientset/versioned"
@@ -53,7 +55,7 @@ func NewConfig() Config {
 		flags: pflag.NewFlagSet("", pflag.ContinueOnError),
 	}
 
-	c.namespace = "dmaas"
+	c.namespace = os.Getenv(envDMaaSNamespaceKey)
 
 	c.flags.StringVar(&c.kubeconfig,
 		"kubeconfig",

--- a/pkg/cmd/server.go
+++ b/pkg/cmd/server.go
@@ -25,11 +25,14 @@ import (
 )
 
 const (
-	// defaultOpenebsNS default openebs namespace
-	defaultOpenebsNS string = "openebs"
+	// envDMaaSNamespaceKey environment variable for dmaas-operator namespace
+	envDMaaSNamespaceKey string = "NAMESPACE"
 
-	// defaultVeleroNs default velero namespace
-	defaultVeleroNs string = "velero"
+	// envOpenebsNamespaceKey environment variable for openebs namespace
+	envOpenebsNamespaceKey string = "OPENEBS_NAMESPACE"
+
+	// envVeleroNamespaceKey environment variable for velero namespace
+	envVeleroNamespaceKey string = "VELERO_NAMESPACE"
 
 	// defaultClientQPS for dmaas-operator
 	defaultClientQPS float32 = 20.0
@@ -47,9 +50,12 @@ type serverOpts struct {
 }
 
 func newServerOpts() *serverOpts {
+	openebsNs := os.Getenv(envOpenebsNamespaceKey)
+	veleroNs := os.Getenv(envVeleroNamespaceKey)
+
 	return &serverOpts{
-		openebsNamespace: defaultOpenebsNS,
-		veleroNamespace:  defaultVeleroNs,
+		openebsNamespace: openebsNs,
+		veleroNamespace:  veleroNs,
 		clientBurst:      defaultClientBurst,
 		clientQPS:        defaultClientQPS,
 		logLevel:         logrus.InfoLevel.String(),
@@ -84,7 +90,6 @@ func NewCmdServer(c Config) *cobra.Command {
 
 		Run: func(cmd *cobra.Command, args []string) {
 			logger := newLogger(opts)
-
 
 			logger.Infof("DMaaS operator started")
 		},

--- a/pkg/cmd/server.go
+++ b/pkg/cmd/server.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2020 The MayaData Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"os"
+	"strings"
+
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+const (
+	// defaultOpenebsNS default openebs namespace
+	defaultOpenebsNS string = "openebs"
+
+	// defaultVeleroNs default velero namespace
+	defaultVeleroNs string = "velero"
+
+	// defaultClientQPS for dmaas-operator
+	defaultClientQPS float32 = 20.0
+
+	// defaultClientBurst for dmaas-operator
+	defaultClientBurst int = 30
+)
+
+type serverOpts struct {
+	openebsNamespace string
+	veleroNamespace  string
+	clientQPS        float32
+	clientBurst      int
+	logLevel         string
+}
+
+func newServerOpts() *serverOpts {
+	return &serverOpts{
+		openebsNamespace: defaultOpenebsNS,
+		veleroNamespace:  defaultVeleroNs,
+		clientBurst:      defaultClientBurst,
+		clientQPS:        defaultClientQPS,
+		logLevel:         logrus.InfoLevel.String(),
+	}
+}
+
+func (s *serverOpts) BindFlags(flags *pflag.FlagSet) {
+	flags.StringVar(&s.openebsNamespace, "openebs-namespace",
+		s.openebsNamespace,
+		"namespace in which openebs is installed")
+	flags.StringVar(&s.veleroNamespace, "velero-namespace",
+		s.veleroNamespace,
+		"namespace in which velero is installed")
+	flags.IntVar(&s.clientBurst, "kube-api-burst",
+		s.clientBurst,
+		"maximum number of requests by the server to the Kubernetes API in a short period of time")
+	flags.Float32Var(&s.clientQPS, "kube-api-qps",
+		s.clientQPS,
+		"maximum number of requests per second by the server to the Kubernetes API once the burst limit has been reached")
+	flags.StringVar(&s.logLevel, "log-level",
+		s.logLevel,
+		fmt.Sprintf("logging level. valid values are %s.", strings.Join(allowedLoggingLevel(), ", ")))
+}
+
+// NewCmdServer returns the command for server
+func NewCmdServer(c Config) *cobra.Command {
+	opts := newServerOpts()
+
+	cmd := &cobra.Command{
+		Use:   "server",
+		Short: "Run dmaas-operator",
+
+		Run: func(cmd *cobra.Command, args []string) {
+			logger := newLogger(opts)
+
+			if lvl, err := logrus.ParseLevel(opts.logLevel); err != nil {
+				logrus.Errorf("Invalid log-level value, using default value")
+			} else {
+				logger.Level = lvl
+			}
+
+			logger.Infof("DMaaS operator started")
+		},
+	}
+
+	opts.BindFlags(cmd.PersistentFlags())
+	c.BindFlags(cmd.PersistentFlags())
+
+	return cmd
+}
+
+func allowedLoggingLevel() []string {
+	var logLevel []string
+
+	for _, l := range logrus.AllLevels {
+		logLevel = append(logLevel, l.String())
+	}
+	return logLevel
+}
+
+// newLogger return logger to log on stdout with json format
+func newLogger(opts *serverOpts) *logrus.Logger {
+	logger := logrus.New()
+	logger.Out = os.Stdout
+
+	if lvl, err := logrus.ParseLevel(opts.logLevel); err != nil {
+		logrus.Errorf("Invalid log-level value, using level %s", logrus.InfoLevel.String())
+		logger.Level = logrus.InfoLevel
+	} else {
+		logger.Level = lvl
+	}
+
+	logger.Formatter = new(logrus.JSONFormatter)
+
+	return logger
+}

--- a/pkg/cmd/server.go
+++ b/pkg/cmd/server.go
@@ -85,11 +85,6 @@ func NewCmdServer(c Config) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			logger := newLogger(opts)
 
-			if lvl, err := logrus.ParseLevel(opts.logLevel); err != nil {
-				logrus.Errorf("Invalid log-level value, using default value")
-			} else {
-				logger.Level = lvl
-			}
 
 			logger.Infof("DMaaS operator started")
 		},

--- a/pkg/cmd/version.go
+++ b/pkg/cmd/version.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2020 The MayaData Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	// Version represent current version of dmaas-operator, set during build
+	Version string
+
+	// GitSHA represent the latest commit from which dmaas-operator built, set during build
+	GitSHA string
+
+	// GitTreeState represent state of git tree, either "clean" or "dirty"
+	GitTreeState string
+)
+
+// NewCmdVersion creates the version command
+func NewCmdVersion() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Show dmaas-operator version",
+		Run: func(cmd *cobra.Command, args []string) {
+			showVersion()
+		},
+	}
+
+	return cmd
+}
+
+func showVersion() {
+	fmt.Printf("GitVersion: %s\n", Version)
+	fmt.Printf("Gitcommit: %s\n", GitSHA)
+	fmt.Printf("GitTreeState: %s\n", GitTreeState)
+
+	fmt.Printf("GO Version: %s\n", runtime.Version())
+	fmt.Printf("GO ARCH: %s\n", runtime.GOARCH)
+	fmt.Printf("GO OS: %s\n", runtime.GOOS)
+}


### PR DESCRIPTION
changes:
- Added basic dmaas-operator binary, with command 'version' and 'server'
- To build the binary, run
```bash
make build
```
It uses following environment variable for namespace:
```bash
NAMESPACE -- dmaas-operator namespace
OPENEBS_NAMESPACE -- openebs namespace
VELERO_NAMESPACE -- velero namespace
```