### PR TITLE
fix(dmaasbackup): creation of multiple schedules for full periodic backup

### DIFF
--- a/pkg/controller/dmaas_backup_controller.go
+++ b/pkg/controller/dmaas_backup_controller.go
@@ -107,7 +107,7 @@ func (d *dmaasBackupController) processBackup(key string) (bool, error) {
 		return shouldRequeue, nil
 	}
 
-	original, err := d.lister.DMaaSBackups(ns).Get(name)
+	original, err := d.dmaasClient.MayadataV1alpha1().DMaaSBackups(ns).Get(name, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			log.Debug("dmaasbackup not found")

--- a/pkg/dmaasbackup/periodic_backup.go
+++ b/pkg/dmaasbackup/periodic_backup.go
@@ -45,6 +45,7 @@ func (d *dmaasBackup) processPeriodicConfigSchedule(obj *v1alpha1.DMaaSBackup) e
 				return err
 			}
 		}
+		d.logger.Infof("Schedule=%s created", emptySchedule.ScheduleName)
 		updateEmptyQueuedVeleroSchedule(obj, emptySchedule, newSchedule)
 
 		lastSchedule := getPreviousVeleroSchedule(obj)

--- a/pkg/dmaasbackup/periodic_backup_test.go
+++ b/pkg/dmaasbackup/periodic_backup_test.go
@@ -557,9 +557,6 @@ func TestCleanupPeriodicSchedule(t *testing.T) {
 				}
 			}
 
-			go veleroFakeInformer.Start(ctx.Done())
-			cache.WaitForCacheSync(ctx.Done(), veleroFakeInformer.Velero().V1().Backups().Informer().HasSynced)
-
 			backupper := NewDMaaSBackupper(
 				veleroNamespace,
 				client,
@@ -567,6 +564,9 @@ func TestCleanupPeriodicSchedule(t *testing.T) {
 				veleroFakeInformer.Velero().V1(),
 				apimachineryclock.NewFakeClock(time.Time{}),
 			)
+
+			veleroFakeInformer.Start(ctx.Done())
+			cache.WaitForCacheSync(ctx.Done(), veleroFakeInformer.Velero().V1().Backups().Informer().HasSynced)
 
 			sort.Sort(sort.Reverse(ScheduleByCreationTimestamp(test.dmaasbackup.Status.VeleroSchedules)))
 			bkpper, ok := backupper.(*dmaasBackup)


### PR DESCRIPTION
DMaaSBackup controller creates a schedule for full periodic backup by reserving schedule name in dmaasbackup resource status. This happens in a two-cycle:
1st reconciliation: Controller will reserve the schedule name and
                    update the dmaasbackup resource with the reserved
                    name.
2nd reconciliation: The controller creates a new schedule if the
                    dmaasbackup resource have reserved schedule name.

DMaaSBackup controller is fetching dmaasbackup resource from informer cache. Sometimes informer cache may not have updated dmaasbackup resources due to delay from etcd. In this case, the controller will get an older version of dmaasbackup in 2nd reconciliation, and it will reserve a new schedule name. Due to this, dmaasbackup will have multiple reserved schedules names.

This PR fixes the above issue in the dmaasbackup controller to fetch the resource from etcd.

Signed-off-by: mayank <mayank.patel@mayadata.io>