### PR TITLE
fix(veleroschedule): checking nil timestamp while sorting veleroschedules

### DIFF
--- a/pkg/controller/base_controller_test.go
+++ b/pkg/controller/base_controller_test.go
@@ -141,9 +141,9 @@ func TestSync(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	_ = informer.Mayadata().V1alpha1().DMaaSBackups().Informer().GetStore().Add(dmaasbackup)
-
 	go informer.Start(ctx.Done())
+
+	_ = client.Tracker().Add(dmaasbackup)
 	go func() {
 		_ = c.Run(ctx)
 	}()

--- a/pkg/dmaasbackup/nonperiodic_backup.go
+++ b/pkg/dmaasbackup/nonperiodic_backup.go
@@ -69,6 +69,8 @@ func (d *dmaasBackup) processNonperiodicConfigSchedule(dbkp *v1alpha1.DMaaSBacku
 				return err
 			}
 		}
+
+		d.logger.Infof("Schedule=%s created", emptySchedule.ScheduleName)
 		updateEmptyQueuedVeleroSchedule(dbkp, emptySchedule, newSchedule)
 		return nil
 	}

--- a/pkg/dmaasbackup/veleroschedules.go
+++ b/pkg/dmaasbackup/veleroschedules.go
@@ -29,6 +29,14 @@ type ScheduleByCreationTimestamp []v1alpha1.VeleroScheduleDetails
 func (o ScheduleByCreationTimestamp) Len() int      { return len(o) }
 func (o ScheduleByCreationTimestamp) Swap(i, j int) { o[i], o[j] = o[j], o[i] }
 func (o ScheduleByCreationTimestamp) Less(i, j int) bool {
+	if o[i].CreationTimestamp == nil || (*o[i].CreationTimestamp).IsZero() {
+		return true
+	}
+
+	if o[j].CreationTimestamp == nil || (*o[j].CreationTimestamp).IsZero() {
+		return false
+	}
+
 	if (*o[i].CreationTimestamp).Equal(o[j].CreationTimestamp) {
 		return o[i].ScheduleName < o[j].ScheduleName
 	}


### PR DESCRIPTION
Changes:
- Added check for nil/empty timestamp while sorting veleroschedules

Fixes: https://github.com/mayadata-io/dmaas-operator/issues/23
Signed-off-by: mayank <mayank.patel@mayadata.io>